### PR TITLE
chore(deps): align dependency versions across GHA repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
     "fast-xml-parser": "^4.5.0"
   },
   "devDependencies": {
-    "@types/node": "^22.8.6",
-    "@typescript-eslint/parser": "^8.12.2",
-    "@vercel/ncc": "^0.38.2",
+    "@types/node": "^22.10.1",
+    "@typescript-eslint/parser": "^8.16.0",
+    "@vercel/ncc": "^0.38.3",
     "eslint": "^8.0.1",
-    "eslint-plugin-github": "^5.0.2",
-    "eslint-plugin-jest": "^28.8.3",
+    "eslint-plugin-github": "^5.1.3",
+    "eslint-plugin-jest": "^28.9.0",
     "jest": "^29.7.0",
     "js-yaml": "^4.1.0",
-    "prettier": "3.3.3",
+    "prettier": "3.4.1",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.3"
+    "typescript": "^5.7.2"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Summary
Align devDependency versions with GHA-VSMarketplacePublisher and GHA-JBMarketplacePublisher for consistency across all GitHub Action repositories.

## Updated Dependencies
- `@types/node`: ^22.8.6 → ^22.10.1
- `@typescript-eslint/parser`: ^8.12.2 → ^8.16.0
- `@vercel/ncc`: ^0.38.2 → ^0.38.3
- `eslint-plugin-github`: ^5.0.2 → ^5.1.3
- `eslint-plugin-jest`: ^28.8.3 → ^28.9.0
- `prettier`: 3.3.3 → 3.4.1
- `typescript`: ^5.6.3 → ^5.7.2