### PR TITLE
refactor(ci): use reusable workflows from CodingWithCalvin/.github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,38 +9,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
-  test-typescript:
-    name: TypeScript Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        id: setup-node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-          cache: npm
-
-      - name: Install Dependencies
-        id: npm-ci
-        run: npm ci
-
-      - name: Check Format
-        id: npm-format-check
-        run: npm run format:check
-
-      - name: Lint
-        id: npm-lint
-        run: npm run lint
-
-      - name: Test
-        id: npm-ci-test
-        run: npm run ci-test
+  build:
+    uses: CodingWithCalvin/.github/.github/workflows/gha-build.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,91 +9,11 @@ on:
         type: string
 
 jobs:
-  changelog:
-    uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
-    secrets: inherit
-
-  release:
-    needs: changelog
-    runs-on: ubuntu-latest
-    outputs:
+  publish:
+    uses: CodingWithCalvin/.github/.github/workflows/gha-publish.yml@main
+    with:
       version: ${{ inputs.version }}
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-          cache: npm
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Rebuild dist
-        run: npm run bundle
-
-      - name: Commit dist changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/
-          git diff --staged --quiet || git commit -m "chore: rebuild dist for v${{ inputs.version }}"
-          git push
-
-      - name: Create and push tag
-        run: |
-          git tag v${{ inputs.version }}
-          git push origin v${{ inputs.version }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ inputs.version }}
-          name: v${{ inputs.version }}
-          body: ${{ needs.changelog.outputs.changelog }}
-
-  notify-bluesky:
-    needs: release
-    uses: CodingWithCalvin/.github/.github/workflows/bluesky-post.yml@main
-    with:
-      post_text: |
-        🚀 Visual Studio VSIX Versioner v${{ needs.release.outputs.version }} has been released!
-
-        Version your Visual Studio extensions with ease!
-
-        [📋 Release Notes](https://github.com/${{ github.repository }}/releases/tag/v${{ needs.release.outputs.version }})
-        [📦 GitHub Marketplace](https://github.com/marketplace/actions/visual-studio-vsix-versioner)
-
-        #github #githubactions #devops #automation
-      embed_url: https://github.com/marketplace/actions/visual-studio-vsix-versioner
-      embed_title: Visual Studio VSIX Versioner
-      embed_description: Version your Visual Studio extensions with ease!
-    secrets:
-      BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
-      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-
-  notify-linkedin:
-    needs: release
-    uses: CodingWithCalvin/.github/.github/workflows/linkedin-post.yml@main
-    with:
-      post_text: |
-        🚀 Visual Studio VSIX Versioner v${{ needs.release.outputs.version }} has been released!
-
-        Version your Visual Studio extensions with ease!
-
-        📋 Release Notes: https://github.com/${{ github.repository }}/releases/tag/v${{ needs.release.outputs.version }}
-        📦 GitHub Marketplace: https://github.com/marketplace/actions/visual-studio-vsix-versioner
-
-        #github #githubactions #devops #automation
-      article_url: https://github.com/marketplace/actions/visual-studio-vsix-versioner
-      article_title: Visual Studio VSIX Versioner
-      article_description: Version your Visual Studio extensions with ease!
-    secrets:
-      LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
-      LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
+      action-name: 'Visual Studio VSIX Versioner'
+      action-slug: 'visual-studio-vsix-versioner'
+      action-description: 'Version your Visual Studio extensions with ease!'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Simplifies workflows by using the new reusable workflows from CodingWithCalvin/.github:

- `build.yml` now calls `gha-build.yml` (Node.js build/test)
- `publish.yml` now calls `gha-publish.yml` (dist rebuild, release, social notifications)

## Test plan

- [ ] Build workflow passes on this PR
- [ ] Test publish workflow manually after merge