### PR TITLE
fix(ci): add path filters to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,25 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '__tests__/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'action.yml'
+      - '.github/workflows/build.yml'
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '__tests__/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'action.yml'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Adds path filters to the build workflow so it only runs when relevant files change:
- `src/**`
- `__tests__/**`
- `package.json`
- `package-lock.json`
- `tsconfig.json`
- `action.yml`
- `.github/workflows/build.yml`

This prevents unnecessary builds when only documentation, config files, or other workflows change.